### PR TITLE
[47] Getters for relevance labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ metaflow.s3.*
 # Notebooks to exclude (eg, code for testing, debugging etc)
 # *.ipynb
 discovery_child_development/notebooks/scrap_scripts/check_taxonomy.ipynb
+discovery_child_development/notebooks/labelling/scraps/*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/discovery_child_development/getters/labels.py
+++ b/discovery_child_development/getters/labels.py
@@ -1,0 +1,23 @@
+"""Module for getting labelled data from S3"""
+import pandas as pd
+from nesta_ds_utils.loading_saving import S3
+from discovery_child_development import S3_BUCKET
+
+
+def get_relevance_labels(filename: str = "relevance_labels_20231212") -> pd.DataFrame:
+    """Get relevance labels from S3
+
+    Returns:
+        pd.DataFrame: A DataFrame containing the relevance labels.
+            Columns are:
+                - id: The ID of the work
+                - source: The source of the data (so far: openalex or patent)
+                - text: The text of the work (title + abstract)
+                - prediction: Relevant (is about preschool-age child development),
+                    Not-relevant, Not-specified (might be about child development but age unclear)
+    """
+    return S3.download_obj(
+        bucket=S3_BUCKET,
+        path_from=f"data/labels/afs_relevance/{filename}.csv",
+        download_as="dataframe",
+    )


### PR DESCRIPTION
Fixes #47 

Simple getter to help fetching relevance labels from S3

@j-gillam Happy for you to wrangle the data further your training pipeline(s)

We can discuss and later harmonise the output from the labelling process to be immediately compatible with the training process.