### PR TITLE
[52] Getter with openalex data for labelling

### DIFF
--- a/discovery_child_development/getters/binary_classifier/openalex_results.py
+++ b/discovery_child_development/getters/binary_classifier/openalex_results.py
@@ -1,0 +1,37 @@
+from nesta_ds_utils.loading_saving import S3
+from discovery_child_development import config, S3_BUCKET
+
+PATH_FROM = "data/openAlex/test_text/"
+
+
+def get_openalex_results(
+    bucket: str = S3_BUCKET,
+    path_from: str = PATH_FROM,
+    sample_size: int = 500,
+):
+    """Downloads the results for a sample of the openalex data from S3, using the huggingface pipeline on the GPT labelled data.
+    See discovery_child_development/pipeline/models/binary_classifier
+
+    Args:
+        bucket (str, optional): Name of the bucket where the data is stored. Defaults to S3_BUCKET.
+        path_from (str, optional): Path to the data. Defaults to PATH_FROM.
+        sample_size (int, optional): Number of samples from each of relevant/not relevant samples. Defaults to 500.
+
+    Returns:
+        pandas.DataFrame: A pandas dataframe with following columns:
+            - id (str): the id of the paper eg "https://openalex.org/W4249228678"
+            - title (str): the title of the paper
+            - abstract (str): the abstract of the paper
+            - text (str): the title/abstract of the paper
+            - labels (str): the label of the paper eg 1:"Relevant" or 0:"Not-relevant"
+            - prediction (str): the prediction of the model eg 1:"Relevant" or 0:"Not-relevant"
+
+    """
+    filename = f"gpt_labelled_results_sample_size_{sample_size}.csv"
+    openalex_data = S3.download_obj(
+        bucket,
+        path_from=f"{path_from}{filename}",
+        download_as="dataframe",
+        kwargs_reading={"index_col": 0},
+    )
+    return openalex_data


### PR DESCRIPTION
---

# Description

This addresses Issue [53](https://github.com/nestauk/discovery_child_development/issues/53). 
Quick PR:

- A getter to retrieve a sample of relevant/not-relevant openalex works for future GPT labelling. Allows you to see the prior label defined by using concepts (labels) and the prediction using the GPT labelled data as training data (predictions).


# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
