### PR TITLE
[56] Getter for relevant crunchbase sample for labelling

### DIFF
--- a/discovery_child_development/getters/binary_classifier/model_results.py
+++ b/discovery_child_development/getters/binary_classifier/model_results.py
@@ -35,3 +35,33 @@ def get_openalex_results(
         kwargs_reading={"index_col": 0},
     )
     return openalex_data
+
+
+def get_crunchbase_results(
+    bucket: str = S3_BUCKET,
+    path_from: str = PATH_FROM,
+):
+    """Downloads the results for a sample of relevant crunchbase data from S3, using the huggingface pipeline on the GPT labelled data.
+    See discovery_child_development/pipeline/models/binary_classifier
+
+    Args:
+        bucket (str, optional): Name of the bucket where the data is stored. Defaults to S3_BUCKET.
+        path_from (str, optional): Path to the data. Defaults to PATH_FROM.
+        sample_size (int, optional): Number of samples from each of relevant/not relevant samples. Defaults to 500.
+
+    Returns:
+        pandas.DataFrame: A pandas dataframe with following columns:
+            - id (str): the crunchbase id
+            - text (str): the long description of the crunchbase work
+            - labels (str): the label of the paper eg 1:"Relevant" or 0:"Not-relevant"
+            - prediction (str): the prediction of the model eg 1:"Relevant" or 0:"Not-relevant"
+
+    """
+    filename = f"gpt_labelled_results_crunchbase.csv"
+    openalex_data = S3.download_obj(
+        bucket,
+        path_from=f"{path_from}{filename}",
+        download_as="dataframe",
+        kwargs_reading={"index_col": 0},
+    )
+    return openalex_data

--- a/discovery_child_development/getters/binary_classifier/model_results.py
+++ b/discovery_child_development/getters/binary_classifier/model_results.py
@@ -1,7 +1,7 @@
 from nesta_ds_utils.loading_saving import S3
 from discovery_child_development import config, S3_BUCKET
 
-PATH_FROM = "data/openAlex/test_text/"
+PATH_FROM = "data/labels/binary_classifier/test_text/"
 
 
 def get_openalex_results(

--- a/discovery_child_development/getters/binary_classifier/prompts_edge_cases.py
+++ b/discovery_child_development/getters/binary_classifier/prompts_edge_cases.py
@@ -11,7 +11,7 @@ def get_examples():
     """
     return S3.download_obj(
         bucket=S3_BUCKET,
-        path_from="data/openAlex/test_text/relevance_classifier_tests.csv",
+        path_from="data/labels/binary_classifier/test_text/relevance_classifier_tests.csv",
         download_as="dataframe",
         kwargs_reading={"engine": "python"},
     )


### PR DESCRIPTION
---

# Description

This addresses Issue [56](https://github.com/nestauk/discovery_child_development/issues/56). 
Quick PR:

- A getter to retrieve a sample of relevant crunchbase works for future GPT labelling (using the Pre-k investments: Final companies [June 2023] csv). Allows you to see the prior label which are designated as all relevant (labels) and the prediction using the GPT labelled data as training data (predictions).


# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
